### PR TITLE
Copilot/publish on GitHub pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,54 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./dist
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,0 +1,65 @@
+# CS559 FPS Range
+
+A first-person shooter training game built with Three.js and Cannon.js.
+
+## Live Demo
+
+The game is deployed and playable at: https://vic233333.github.io/CS559-project-fps/
+
+## Features
+
+- First-person shooter mechanics
+- Physics simulation with Cannon.js
+- 3D graphics with Three.js
+- Wave-based gameplay
+- Auto-play demo mode
+
+## Development
+
+### Prerequisites
+
+- Node.js 20 or higher
+- npm
+
+### Installation
+
+```bash
+npm install
+```
+
+### Running Locally
+
+```bash
+npm run dev
+```
+
+The game will open in your browser at `http://localhost:5173`
+
+### Building
+
+```bash
+npm run build
+```
+
+The built files will be in the `dist` directory.
+
+## Controls
+
+- **Move**: WASD
+- **Sprint**: Shift
+- **Jump**: Space
+- **Pause**: Esc
+- **Toggle Mode**: Use buttons in the header
+
+## Deployment
+
+This project is automatically deployed to GitHub Pages using GitHub Actions. When changes are pushed to the `main` branch, the workflow:
+
+1. Builds the project using Vite
+2. Deploys the built files to GitHub Pages
+
+You can also manually trigger the deployment from the Actions tab in GitHub.
+
+## License
+
+ISC

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "bugs": {
     "url": "https://github.com/vic233333/CS559-project-fps/issues"
   },
-  "homepage": "https://github.com/vic233333/CS559-project-fps#readme",
+  "homepage": "https://vic233333.github.io/CS559-project-fps/",
   "dependencies": {
     "cannon-es": "^0.20.0",
     "three": "^0.170.0"


### PR DESCRIPTION
This pull request sets up automated deployment to GitHub Pages and improves project documentation. The most important changes are the addition of a GitHub Actions workflow for deployment and a comprehensive update to the `README.md` to guide users and contributors.

Deployment automation:

* Added `.github/workflows/deploy.yml` to automate building and deploying the project to GitHub Pages using GitHub Actions. This workflow runs on pushes to `main` and can also be triggered manually. It builds the project and deploys the output from the `dist` directory.
* Updated the `homepage` field in `package.json` to point to the live GitHub Pages URL, ensuring correct links for users and tools.

Documentation improvements:

* Rewrote `README.md` to include a project overview, live demo link, feature list, setup instructions, controls, and deployment details, making it easier for new users and contributors to get started.